### PR TITLE
Review screen show household income w/o supplement

### DIFF
--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_body.yml
@@ -711,11 +711,11 @@ attachment:
       - "EAEDC": ${yesno(public_assistance_kinds['EAEDC'])}
       - "VA": ${yesno(public_assistance_kinds['VA Benefits'])}
       - "below_poverty_level": ${yesno(household_income_qualifies) if need_income else "No"}
-      - "weekly": ${'No'}
-      - "biweekly": ${'No'}
-      - "monthly": ${'Yes'}
-      - "annually": ${'No'}
-      - "income_amount": ${thousands(hh_income.total(times_per_year=12), show_decimals=True)}
+      - "weekly": ${'Yes' if need_income and hh_income.times_per_year == 52 else 'No'}
+      - "biweekly": ${'Yes' if need_income and hh_income.times_per_year == 26 else 'No'}
+      - "monthly": ${'Yes' if need_income and hh_income.times_per_year not in [52, 26, 1] else 'No'}
+      - "annually": ${'Yes' if need_income and hh_income.times_per_year == 1 else 'No'}
+      - "income_amount": ${thousands(hh_income.total(times_per_year=12) if hh_income.times_per_year not in [52, 26, 1] else hh_income.total(times_per_year=hh_income.times_per_year), show_decimals=True)}
       - "household_additional_size": ${household_additional_size if need_income and has_household_members else (0 if need_income else '')}
       - "household_size": ${household_size if need_income else ''}
       - "other_income": ${'Included above' if need_income else ''}

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_body.yml
@@ -83,9 +83,6 @@ code: |
     affidavit_of_indigency_filing_court
 
     set_empty_fees
-    # trigger other computed values
-    # filing_fees_amount
-    annually
   ask_affidavit_questions = True
 ---
 depends on:
@@ -358,7 +355,6 @@ code: |
   if public_assistance_kinds.any_true():
     hh_income = DAEmpty()
     household_additional_size = DAEmpty()
-  set_empty_income = True
 ---
 id: user benefits
 question: |
@@ -444,7 +440,7 @@ subquestion: |
 id: select fees waived
 question: |
   What fees do you need the court to waive or pay?
-subquestion: | 
+subquestion: |
   You do not need to list every cost right now. You can file a separate fee waiver request for
   fees that come up later in your case.
 
@@ -669,16 +665,6 @@ code: |
     recipient_email = ""
 ---
 code: |
-  if not (hh_income.times_per_year in [52,26,12,1]):
-    monthly_income = hh_income.total(times_per_year=12)
-    hh_income.times_per_year = 12
-    hh_income.value = monthly_income
-  weekly = 'Yes' if need_income and hh_income.times_per_year == 52 else 'No'
-  biweekly = 'Yes' if need_income and hh_income.times_per_year == 26 else 'No'
-  monthly = 'Yes' if need_income and hh_income.times_per_year == 12 else 'No'
-  annually = 'Yes' if need_income and hh_income.times_per_year == 1 else 'No'
----
-code: |
   # filing_fees_amount = fees['E-filing'].amount + fees['Filing fee'].amount if defined("fees['Filing fee'].amount") and fees['Filing fee'].waive else fees['E-filing'].amount
   filing_fees_amount = fees['Filing fee'].amount
 ---
@@ -725,11 +711,11 @@ attachment:
       - "EAEDC": ${yesno(public_assistance_kinds['EAEDC'])}
       - "VA": ${yesno(public_assistance_kinds['VA Benefits'])}
       - "below_poverty_level": ${yesno(household_income_qualifies) if need_income else "No"}
-      - "weekly": ${weekly}
-      - "biweekly": ${biweekly}
-      - "monthly": ${monthly}
-      - "annually": ${annually}
-      - "income_amount": ${hh_income.total(times_per_year=hh_income.times_per_year)}
+      - "weekly": ${'No'}
+      - "biweekly": ${'No'}
+      - "monthly": ${'Yes'}
+      - "annually": ${'No'}
+      - "income_amount": ${thousands(hh_income.total(times_per_year=12), show_decimals=True)}
       - "household_additional_size": ${household_additional_size if need_income and has_household_members else (0 if need_income else '')}
       - "household_size": ${household_size if need_income else ''}
       - "other_income": ${'Included above' if need_income else ''}

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
@@ -367,6 +367,13 @@ fields:
   - no label: users[0].nonemployment.there_is_another
     datatype: yesnoradio
 ---
+id: any non-employment incomes
+question: |
+  Do you have any sources of income not from employment?
+fields:
+  - no label: users[0].nonemployment.there_are_any
+    datatype: yesnoradio
+---
 code: |
   def job_description():
     return comma_and_list([f"{job.source} {'(self-employed)' if job.is_self_employed else ('for ' + job.employer_name_address_phone())}" for job in users[0].jobs])

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
@@ -289,7 +289,7 @@ fields:
 ---
 id: any non-employment incomes
 question: |
-  Do you have any of the below sources of income, not from employment?
+  Do you get money from any of the below sources, not from employment?
 fields:
   - no label: users[0].nonemployment.selected_types
     datatype: checkboxes
@@ -356,12 +356,10 @@ code: |
 ---
 id: any more non-employment incomes
 question: |
-  Do you have any additional sources of income not from employment?
+  Do you get any other money that is not from a job?
 subquestion: |
-  % if users[0].nonemployment.complete_elements() > 1:
-  You have already told us about your incomes from ${ list_incomes(users[0].nonemployment.complete_elements()) }.
-  % else:
-  You have already told us about your income from ${ list_incomes(users[0].nonemployment.complete_elements()) }.
+  % if len(users[0].nonemployment.complete_elements()) >= 1:
+  You have already told us about the money you get from ${ list_incomes(users[0].nonemployment.complete_elements()) }.
   % endif
 fields:
   - no label: users[0].nonemployment.there_is_another
@@ -369,7 +367,11 @@ fields:
 ---
 id: any non-employment incomes
 question: |
-  Do you have any sources of income not from employment?
+  Do you get any money that is not from a job?
+subquestion: |
+  % if defined("users[0].jobs") and len(users[0].jobs.complete_elements()) >= 1:
+  You have already told about your income from these jobs: ${ comma_and_list([job.source for job in users[0].jobs.complete_elements()]) }.
+  % endif
 fields:
   - no label: users[0].nonemployment.there_are_any
     datatype: yesnoradio

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
@@ -1002,7 +1002,7 @@ attachments:
       - "user_car_year": ${ user_car_year if user_owns_car else ""}
       - "user_car_make": ${ user_car_make if user_owns_car else ""}
       - "user_car_value": ${ thousands(user_car_value, show_decimals=True) if user_owns_car else "" }
-      - "user_car_debt": ${ thousands(user_car_debt, show_decimals=True) if user_owns_car else "" }
+      - "user_car_debt": ${ thousands(user_car_debt, show_decimals=True) if user_owns_car and user_car_loan else "" }
       - "user_accounts_balance": ${ comma_and_list([currency(ac.balance) for ac in users[0].accounts], comma_string=',\n', and_string=',\n') }
       - "user_accounts_type": ${ list_accounts_source(users[0].accounts) }
       - "user_property_type": ${ user_property_type if user_owns_property else "" }

--- a/docassemble/ALAffidavitOfIndigency/data/questions/review_page.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/review_page.yml
@@ -28,6 +28,7 @@ review:
     fields:
       - public_assistance_kinds
       - recompute:
+        - reinit_hh_income
         - is_indigent
         - need_income
         - need_supplement
@@ -37,6 +38,15 @@ review:
       % else:
       **No public benefits received**
       % endif
+  - label: Edit
+    show if: need_income and not need_supplement
+    fields:
+      - hh_income.value
+      - recompute:
+        - household_income_qualifies
+        - need_supplement
+    button: |
+      **Total household income, after tax:** ${ currency(hh_income.value) }, ${ times_per_year(times_per_year_list, hh_income.times_per_year) }
   - label: Edit
     fields:
       - can_afford
@@ -173,3 +183,11 @@ code: |
   household_additional_size = len(household)
   household_size = household_additional_size + 1
   update_household_number = True
+---
+code: |
+  if not public_assistance_kinds.any_true() and defined("hh_income") and isinstance(hh_income, DAEmpty):
+    globals().pop('hh_income', None)
+    globals().pop('household_income_qualifies', None)
+  hh_income.value
+  household_income_qualifies
+  reinit_hh_income = True


### PR DESCRIPTION
Fix #9, and several other review screen bugs including:
* show the household income in the pdf if user edits benefits to have none
* an error in `users[0].nonemployment` when being triggered from the review screen
* removed useless intermediate variables that would cause logic errors after editing certain values

One choice that was made: if the user edits their choices to say that they can afford the payments, we don't show them the `doesnt_qualify_ending` screen. This is likely to get the affidavit denied, but otherwise, our program will essentially prevent anyone from editing certain values unless they say that they can't afford things. Willing to hear other arguments to see if one way is better for users or not.