### PR TITLE
Job deduction

### DIFF
--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
@@ -208,7 +208,7 @@ code: |
 ---
 code: |
   household[i].jobs[j].source
-  household[i].jobs[j].net
+  household[i].jobs[j].deduction
   household[i].jobs[j].employer.name.first
   household[i].jobs[j].times_per_year
   household[i].jobs[j].complete = True
@@ -491,14 +491,16 @@ fields:
   - How many hours does ${ household[i] } work in each period?: household[i].jobs[j].hours_per_period
     datatype: number
     show if: household[i].jobs[j].is_hourly
-  - What does ${ household[i] } get paid after taxes?: household[i].jobs[j].net
+  - What does ${ household[i] } get paid?: household[i].jobs[j].value
     datatype: currency
     show if: household[i].jobs[j].is_hourly
-  - What does ${ household[i] } gets paid hourly, after taxes?: household[i].jobs[j].net
+  - What does ${ household[i] } get paid hourly?: household[i].jobs[j].value
     datatype: currency
     show if:
       variable: household[i].jobs[j].is_hourly
       is: False
+  - How much is deducted from ${ household[i] }'s pay each period: household[i].jobs[j].deduction
+    datatype: currency
 ---
 generic object: ALItemizedJob
 question: |

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
@@ -339,7 +339,7 @@ subquestion: |
   You have already told us about your ${ users[0].nonemployment.complete_elements().as_noun("income") } from ${ list_incomes(users[0].nonemployment) }.
   % endif
 fields:
-  - Times per year you recieve this income: users[0].nonemployment[i].times_per_year
+  - Times per year you receive this income: users[0].nonemployment[i].times_per_year
     input type: radio
     code: |
       times_per_year_list

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_of_indigency_supplement_body.yml
@@ -888,8 +888,10 @@ columns:
       row_item.name.full() if defined("row_item.name.first") else ""
   - Occupations: |
       comma_and_list(row_item.jobs.sources())
-  - Income: |
-      currency(row_item.jobs.net_total())
+  - Annual Gross Income: |
+      currency(row_item.jobs.total())
+  - Annual Deductions: |
+      currency(row_item.jobs.deductions())
 edit:
   - name.first
   - jobs.revisit
@@ -935,7 +937,7 @@ objects:
 ---
 comment: |
   According to this form and the main affidavit, everyone else in the household (besides yourself)
-  is considered a dependent. 
+  is considered a dependent.
   See https://github.com/SuffolkLITLab/docassemble-AffidavitOfIndigencySupplement/issues/26. 
 attachments:
   - name: affidavit to indigency supplement post interview instructions
@@ -946,7 +948,8 @@ attachments:
   - name: affidavit to indigency supplement attachment
     filename: affidavit_of_indigency_supplement.pdf
     variable name: affidavit_of_indigency_supplement_attachment[i]
-    editable: False
+    # Needs to be editable to view all of the text areas
+    editable: True
     skip undefined: False
     pdf template file: affidavit_of_indigency_supplement.pdf
     fields:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALAffidavitOfIndigency',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLine', 'docassemble.MassAccess', 'docassemble.PovertyScale', 'docassemble.income', 'docassemble.ALMassachusetts>=0.1.2'],
+      install_requires=['docassemble.AssemblyLine', 'docassemble.MassAccess', 'docassemble.PovertyScale', 'docassemble.ALToolbox>=0.7.1', 'docassemble.ALMassachusetts>=0.1.2'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALAffidavitOfIndigency/', package='docassemble.ALAffidavitOfIndigency'),
      )


### PR DESCRIPTION
New changes to the `al_income` module means that `ALJob` does stuff with `.deduction`, not `.net` now. Those changes are in https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/144; don't merge until that PR has a released version on PyPi (0.7.0 or above).