### PR TITLE
[codex] Guard fee waiver income cadence label

### DIFF
--- a/docassemble/ALAffidavitOfIndigency/affidavit_helpers.py
+++ b/docassemble/ALAffidavitOfIndigency/affidavit_helpers.py
@@ -1,0 +1,5 @@
+from docassemble.ALToolbox.al_income import times_per_year as altoolbox_times_per_year
+
+
+def safe_times_per_year(times_per_year_list, times_per_year):
+    return str(altoolbox_times_per_year(times_per_year_list, times_per_year))

--- a/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_body.yml
+++ b/docassemble/ALAffidavitOfIndigency/data/questions/affidavit_body.yml
@@ -9,6 +9,7 @@ include:
 ---
 modules:
   - docassemble.PovertyScale.poverty
+  - docassemble.ALAffidavitOfIndigency.affidavit_helpers
 ---
 mandatory: True
 variable name: interview_metadata["affidavit_of_indigency"]
@@ -592,7 +593,7 @@ subquestion: |
   
   **You earn less than the income limit.**
 
-  You said that your ${times_per_year(times_per_year_list, hh_income.times_per_year).lower()} income
+  You said that your ${safe_times_per_year(times_per_year_list, hh_income.times_per_year).lower()} income
   is ${currency(hh_income.total(times_per_year=hh_income.times_per_year))}.
   
   The limit for a household of ${nice_number(household_size)} is 125% of


### PR DESCRIPTION
## Summary

Adds a small helper around `times_per_year()` and uses it in the fee waiver income-limit explanation so the template always calls `.lower()` on a string.

## Why

The integrated MATC 1A divorce flow hit an `AttributeError` when the cadence lookup returned a non-string value while rendering the fee waiver summary.

## Validation

Locally deployed with the integrated MATC packages in the docassemble Docker container and ran the MATC1AJointPetition API driver end to end to the final download screen.